### PR TITLE
fix: standalone_mysql deploy template

### DIFF
--- a/deploy/dnf/docker-compose/standalone_mysql/docker-compose.yaml
+++ b/deploy/dnf/docker-compose/standalone_mysql/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       - MYSQL_HOST=mysql
       - MYSQL_PORT=4000
       # 远程数据库root密码
+      - MAIN_MYSQL_ROOT_PASSWORD=88888888
       - DNF_DB_ROOT_PASSWORD=88888888
       # dnf-gate-server配置
       - GATE_AES_KEY=a1b2c3d4e5f6789012345678901234567890abcdef0123456789abcdef012345


### PR DESCRIPTION
Hi,

I'm not sure if this is the expected behavior, but on my machine

https://github.com/llnut/dnf/blob/4056efe9e5ca577d33bbac41fd14f6c0a661e9a0/build/dnf_data/home/template/init/wait_for_mysql.sh#L12

always have the default `88888888` value, so `wait_for_mysql.sh` hangs silently until it errors after the max retries.

`CUR_MAIN_DB_ROOT_PASSWORD` is set here

https://github.com/llnut/dnf/blob/4056efe9e5ca577d33bbac41fd14f6c0a661e9a0/build/dnf_data/docker-entrypoint.sh#L55-L59